### PR TITLE
[FEATURE] Add compatibility for v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0+",
 	"keywords": ["TYPO3 CMS", "Link Handler", "Links", "Language"],
 	"require": {
-		"typo3/cms": "^8.7"
+		"typo3/cms": "^8.7 || ^9.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0+",
 	"keywords": ["TYPO3 CMS", "Link Handler", "Links", "Language"],
 	"require": {
-		"typo3/cms": "^8.7 || ^9.5"
+		"typo3/cms-core": "^8.7 || ^9.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,8 +12,8 @@ $EM_CONF[$_EXTKEY] = array(
 	'author_company' => 'b:dreizehn GmbH',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '8.7.0-8.7.99',
-			'recordlist' => '8.7.0-8.7.99',
+			'typo3' => '8.7.0-9.5.99',
+			'recordlist' => '8.7.0-9.5.99',
 		),
 	),
 );


### PR DESCRIPTION
Added TYPO3 v9 version to composer.json and ext_emconf.php. Just tested it, it works. It would be nice if a compatibility release will be published.