### PR TITLE
[TASK] Add extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
 		"psr-4": {
 			"CMSExperts\\Link2language\\": "Classes/"
 		}
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "link2language"
+		}
 	}
 }


### PR DESCRIPTION
This avoids the

TYPO3 Extension Package "cmsexperts/link2language", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3

deprecation message introduced in typo3/cms-composer-installers 3.1.0
and make it future-proof.