### PR TITLE
Fix autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"B13\\Link2language\\": "Classes/"
+			"B13\\Link2Language\\": "Classes/"
 		}
 	},
 	"extra": {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,8 +1,8 @@
 <?php
 defined('TYPO3_MODE') or die();
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_parsehtml_proc.php']['removeParams_PostProc']['link2language'] = \B13\Link2language\RteParserTypoLinkHook::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_parsehtml_proc.php']['removeParams_PostProc']['link2language'] = \B13\Link2Language\RteParserTypoLinkHook::class;
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-    'TCEMAIN.linkHandler.page.handler = B13\\Link2language\\LinkHandler\\PageLinkHandler'
+    'TCEMAIN.linkHandler.page.handler = B13\\Link2Language\\LinkHandler\\PageLinkHandler'
 );


### PR DESCRIPTION
autoload fails in classmap-authoritative mode ( e.g. in deployment scenarios like surf)

Problem ist the lower l in the Namespace
"autoload": { "psr-4": { "B13\\Link2language\\": "Classes/" } },
should be
"autoload": { "psr-4": { "B13\\Link2Language\\": "Classes/" } },

Also in ext_localconf.php
\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig( 'TCEMAIN.linkHandler.page.handler = B13\\Link2language\\LinkHandler\\PageLinkHandler' );
should be
\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig( 'TCEMAIN.linkHandler.page.handler = B13\\Link2Language\\LinkHandler\\PageLinkHandler' );

You can reproduce the issue with
composer du --classmap-authoritative