### PR TITLE
[BUGFIX] Re-enable colPos label/name localization

### DIFF
--- a/Classes/LinkHandler/PageLinkHandler.php
+++ b/Classes/LinkHandler/PageLinkHandler.php
@@ -150,7 +150,7 @@ class PageLinkHandler extends \TYPO3\CMS\Backend\LinkHandler\PageLinkHandler
 
             $colPosMapping = [];
             foreach ($colPosArray as $colPos => $label) {
-                $colPosMapping[(int)($colPos)] = $label;
+                $colPosMapping[(int)($colPos)] = $this->getLanguageService()->sL($label);
             }
             // Enrich list of records
             $groupedContentElements = [];


### PR DESCRIPTION
### Issue

After the last upgrade to version `4.0`, localized colPos labels/names are no longer resolved.

### How to reproduce

Set an `LLL:EXT:...` string as columns name in `*.tsconfig` e.g.:

```
mod.web_layout.BackendLayouts {
  Stage {
    # ...
    config {
      backend_layout {
        # ...
        rows {
          1 {
            columns {
              1 {
                name = LLL:EXT:sitepackage/Resources/Private/Language/locallang_layout.xlf:backend_layout.column.stage
                # ...
```

As a result the "Link Browser" does not show the expected localized column name:

![stage](https://github.com/user-attachments/assets/00d71327-bbcb-4b06-b45c-f7062f442c3c)

### Bugfix

LanguageService::sL is used to resolve the colPos name ($label).

      
 